### PR TITLE
fix: dont bleed all of antlr to classpath

### DIFF
--- a/clientscript-compiler/build.gradle.kts
+++ b/clientscript-compiler/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 version = "1.0.1-SNAPSHOT"
 
 dependencies {
-    api(project(":runescript-compiler")) {
-        exclude("com.ibm.icu", "icu4j")
-    }
+    api(project(":runescript-compiler"))
     implementation(libs.netty.buffer)
     implementation(libs.fourkoma)
     implementation(libs.clikt)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,8 @@ clikt = "5.0.2"
 gson = "2.11.0"
 
 [libraries]
-antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
+antlrCore = { module = "org.antlr:antlr4", version.ref = "antlr" }
+antlrRuntime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 inlineLogger = { module = "com.michael-bull.kotlin-inline-logger:kotlin-inline-logger", version.ref = "inlineLogger" }

--- a/runescript-parser/build.gradle.kts
+++ b/runescript-parser/build.gradle.kts
@@ -8,7 +8,16 @@ val antlrOutput = "src/main/java/me/filby/neptune/runescript/antlr"
 val antlrPackage = "me.filby.neptune.runescript.antlr"
 
 dependencies {
-    antlr(libs.antlr)
+    antlr(libs.antlrCore)
+    api(libs.antlrRuntime)
+}
+
+// the gradle antlr plugin adds all of antlr to runtimeClasspath,
+// workaround that https://github.com/gradle/gradle/issues/820
+configurations {
+    api {
+        setExtendsFrom(extendsFrom.filterNot { it == antlr.get() })
+    }
 }
 
 kotlin {


### PR DESCRIPTION
This change means that the following do not get added to the classpath or included in binary distributions
antlr4-4.13.2.jar
antlr-runtime-3.5.3.jar
org.abego.treelayout.core-1.0.3.jar
ST4-4.3.4.jar

additionally the explicit exclusion for icu4j isnt needed anymore